### PR TITLE
Fix item name grammar

### DIFF
--- a/iinit.cpp
+++ b/iinit.cpp
@@ -80,8 +80,8 @@ object Objects[TOTALITEMS] =
     2,
     THING,
     "twisted piece of metal",
-    "thieve's pick",
-    "thieve's pick"
+    "thieves' pick",
+    "thieves' pick"
   },
   {
     3,


### PR DESCRIPTION
Could also make it "thief's pick". Definitely not "thieve's" though.