### PR TITLE
Split out a reusable game core to support alternative front-ends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,15 @@ if(WIN32)
   link_directories(${CMAKE_BINARY_DIR}/installed/Release/lib/${PDC_WINDOW_TYPE})
 endif()
 
-add_executable(omega
+# ---------------------------------------------------------------------------
+# omega-core: game logic shared between the standalone executable and the
+# Godot GDExtension. Excludes omega.cpp (main + globals), scr.cpp (curses
+# rendering), and interactive_menu.cpp (curses UI). The latter two will be
+# replaced by scr_godot.cpp and Godot scenes in the GDExtension build.
+# ---------------------------------------------------------------------------
+add_library(omega-core STATIC
+  src/game_session.cpp
+  src/globals.cpp
   src/abyss.cpp
   src/aux1.cpp
   src/aux2.cpp
@@ -91,7 +99,6 @@ add_executable(omega
   src/guild2.cpp
   src/house.cpp
   src/iinit.cpp
-  src/interactive_menu.cpp
   src/inv.cpp
   src/item.cpp
   src/itemf1.cpp
@@ -107,10 +114,8 @@ add_executable(omega
   src/mspec.cpp
   src/mstrike.cpp
   src/mtalk.cpp
-  src/omega.cpp
   src/priest.cpp
   src/save.cpp
-  src/scr.cpp
   src/scrolling_buffer.cpp
   src/site1.cpp
   src/site2.cpp
@@ -120,6 +125,17 @@ add_executable(omega
   src/util.cpp
   src/village.cpp
 )
+target_include_directories(omega-core PUBLIC src)
+
+# ---------------------------------------------------------------------------
+# Standalone executable (curses-based, existing build)
+# ---------------------------------------------------------------------------
+add_executable(omega
+  src/omega.cpp
+  src/interactive_menu.cpp
+  src/scr.cpp
+)
+target_link_libraries(omega PRIVATE omega-core)
 
 add_custom_command(
   TARGET omega POST_BUILD
@@ -173,7 +189,7 @@ if(WIN32)
       msvcrtd
     )
   endif()
-  target_link_libraries(omega
+  target_link_libraries(omega PRIVATE
     $<$<CONFIG:Debug>:${DEBUG_LIBS}>
     $<$<CONFIG:Release>:${RELEASE_LIBS}>
   )

--- a/src/clrgen.cpp
+++ b/src/clrgen.cpp
@@ -14,10 +14,10 @@ Omega. If not, see <https://www.gnu.org/licenses/>.
 */
 
 #include "clrgen.h"
+#include "omega_curses.h"
 
 #include <cstdio>
 #include <cstdlib>
-#include <curses.h>
 
 void clrgen_init()
 {

--- a/src/defs.h
+++ b/src/defs.h
@@ -430,7 +430,7 @@ constexpr int NUMROOMNAMES = 30;
 
 #include "clrgen.h"
 
-#include <curses.h>
+#include "omega_curses.h"
 #define CLR(fg)       CLR_##fg##_BLACK
 #define CLRS(fg, bg)  CLR_##fg##_##bg
 

--- a/src/game_session.cpp
+++ b/src/game_session.cpp
@@ -1,0 +1,233 @@
+/*
+Omega copyright (C) by Laurence Raphael Brothers, 1987,1988,1989
+Modifications copyright (C) by Lyle Tafoya, 2019, 2021-2023
+
+This file is part of Omega.
+
+Omega is free software: you can redistribute it and/or modify it under the terms
+of the GNU General Public License as published by the Free Software Foundation,
+either version 3 of the License, or (at your option) any later version.
+
+Omega is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+Omega. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+// Game-session initialisation and main loop, extracted from omega.cpp so that
+// front-ends other than the curses main() can drive the game.
+
+#include "game_session.h"
+
+#include "glob.h"
+#include "scr.h"
+
+#include <cctype>
+#include <filesystem>
+#include <format>
+#include <limits>
+#include <random>
+#include <string>
+
+#ifdef PDC_GL_BUILD
+extern "C"
+{
+#  include <pdcgl.h>
+}
+#endif
+
+extern std::string get_username();
+extern bool title_menu();
+extern void init_game(bool play_yourself = false);
+extern void omega_title();
+
+// environment is the environment about to be generated, or -1 for the first
+// time, or -2 if we want to restore the random number point
+void initrand(int environment, int level)
+{
+  static int store;
+  int seed;
+
+  if(environment >= 0)
+  {
+    store = random_range((std::numeric_limits<int>::max)());
+  }
+  if(environment == E_RANDOM)
+  {
+    seed = static_cast<int>(time(nullptr));
+  }
+  else if(environment == E_RESTORE)
+  {
+    seed = store;
+  }
+  else
+  {
+    seed = level_seed[environment] + 1000 * level;
+  }
+  generator.seed(seed);
+}
+
+bool game_restore(const std::filesystem::path &save_file_path)
+{
+  if(std::filesystem::exists(save_file_path) && restore_game(save_file_path.string()))
+  {
+    std::filesystem::remove(save_file_path);
+    return true;
+  }
+  return false;
+}
+
+void init_world()
+{
+  for(int env = 0; env <= E_MAX; ++env)
+  {
+    level_seed[env] = random_range((std::numeric_limits<int>::max)());
+  }
+  load_country();
+  for(int i = 0; i < NUMCITYSITES; ++i)
+  {
+    CitySiteList[i][0] = false;
+  }
+  load_city(true);
+  WIDTH               = 64;
+  LENGTH              = 64;
+  Player.x            = 62;
+  Player.y            = 21;
+  Current_Environment = E_CITY;
+  queue_message("You pass through the massive gates of Rampart, the city.");
+}
+
+void inititem(int reset)
+{
+  if(reset)
+  {
+    shuffle(scroll_ids, 30);
+    shuffle(potion_ids, 20);
+    shuffle(stick_ids, 20);
+    shuffle(boot_ids, 20);
+    shuffle(cloak_ids, 20);
+    shuffle(ring_ids, 20);
+  }
+  for(int i = 0; i < NUMSCROLLS; ++i)
+  {
+    Objects[SCROLLID + i].objstr = scrollname(i);
+  }
+  for(int i = 0; i < NUMPOTIONS; ++i)
+  {
+    Objects[POTIONID + i].objstr = potionname(i);
+  }
+  Objects[ARTIFACTID + 10].objstr = potionname(18);
+  Objects[ARTIFACTID + 13].objstr = potionname(19);
+  for(int i = 0; i < NUMSTICKS; ++i)
+  {
+    Objects[STICKID + i].objstr = stickname(i);
+  }
+  for(int i = 0; i < NUMBOOTS; ++i)
+  {
+    Objects[BOOTID + i].objstr = bootname(i);
+  }
+  for(int i = 0; i < NUMCLOAKS; ++i)
+  {
+    Objects[CLOAKID + i].objstr = cloakname(i);
+  }
+  for(int i = 0; i < NUMRINGS; ++i)
+  {
+    Objects[RINGID + i].objstr = ringname(i);
+  }
+}
+
+InitResult init_game_session()
+{
+#ifdef USER_DEFINED_OMEGALIB
+  if(!(Omegalib = getenv("OMEGALIB")))
+#endif
+  {
+    Omegalib = OMEGALIB;
+  }
+
+  if(!filecheck())
+  {
+    return InitResult::Failed;
+  }
+
+  initgraf();
+#ifdef PDC_GL_BUILD
+  PDC_set_title("Omega Rebirth");
+#endif
+  initdirs();
+  initrand(E_RANDOM, 0);
+
+  omega_title();
+
+  Player.name         = get_username();
+  Player.name.front() = static_cast<char>(std::toupper(static_cast<unsigned char>(Player.name.front())));
+  optionset(SHOW_COLOUR, Player);
+  bool continuing = false;
+
+#ifdef MULTI_USER_SYSTEM
+  continuing = game_restore(std::format("{}saves/{}/{}.sav", Omegalib, get_username(), Player.name));
+  showscores();
+  if(!continuing)
+  {
+    init_game(false);
+  }
+#else
+  continuing = title_menu();
+#endif
+
+  if(continuing)
+  {
+    queue_message("Your adventure continues....");
+    if(Lunarity == 1)
+    {
+      queue_message("You feel vitalized by the moon!");
+    }
+    else if(Lunarity == -1)
+    {
+      queue_message("The feel enervated by the moon!");
+    }
+  }
+
+  timeprint();
+  calc_melee();
+  if(Current_Environment != E_COUNTRYSIDE)
+  {
+    showroom(Level->site[Player.x][Player.y].roomnumber);
+  }
+  else
+  {
+    terrain_check(false);
+  }
+
+  if(optionp(SHOW_COLOUR, Player))
+  {
+    colour_on();
+  }
+  else
+  {
+    colour_off();
+  }
+
+  screencheck(Player.x, Player.y);
+  xredraw();
+
+  return continuing ? InitResult::Continued : InitResult::NewGame;
+}
+
+void run_game_loop(bool reset_clock)
+{
+  while(true)
+  {
+    if(Current_Environment == E_COUNTRYSIDE)
+    {
+      p_country_process();
+    }
+    else
+    {
+      time_clock(reset_clock);
+    }
+    reset_clock = false;
+  }
+}

--- a/src/game_session.h
+++ b/src/game_session.h
@@ -1,0 +1,38 @@
+/*
+Omega copyright (C) by Laurence Raphael Brothers, 1987,1988,1989
+Modifications copyright (C) by Lyle Tafoya, 2019, 2021-2023
+
+This file is part of Omega.
+
+Omega is free software: you can redistribute it and/or modify it under the terms
+of the GNU General Public License as published by the Free Software Foundation,
+either version 3 of the License, or (at your option) any later version.
+
+Omega is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+Omega. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+// Outcome of init_game_session(): Failed if data files are missing or
+// initialization otherwise fails; NewGame for a fresh character;
+// Continued for a restored save.
+enum class InitResult
+{
+  Failed,
+  NewGame,
+  Continued
+};
+
+// Initializes the game world and rendering. Returns once the world is set up
+// and the first screen has been drawn; the first turn has NOT yet run.
+InitResult init_game_session();
+
+// Runs the main game loop. Blocks until the player quits.
+// Pass reset_clock = true for a new game (resets Tick/Player.click on the
+// first turn). In the GDExtension build this is called on a background thread.
+void run_game_loop(bool reset_clock);

--- a/src/game_session.h
+++ b/src/game_session.h
@@ -16,7 +16,8 @@ You should have received a copy of the GNU General Public License along with
 Omega. If not, see <https://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#ifndef OMEGA_GAME_SESSION_H_
+#define OMEGA_GAME_SESSION_H_
 
 // Outcome of init_game_session(): Failed if data files are missing or
 // initialization otherwise fails; NewGame for a fresh character;
@@ -36,3 +37,5 @@ InitResult init_game_session();
 // Pass reset_clock = true for a new game (resets Tick/Player.click on the
 // first turn). In the GDExtension build this is called on a background thread.
 void run_game_loop(bool reset_clock);
+
+#endif

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -1,0 +1,144 @@
+/*
+Omega copyright (C) by Laurence Raphael Brothers, 1987,1988,1989
+Modifications copyright (C) by Lyle Tafoya, 2019, 2021-2023
+
+This file is part of Omega.
+
+Omega is free software: you can redistribute it and/or modify it under the terms
+of the GNU General Public License as published by the Free Software Foundation,
+either version 3 of the License, or (at your option) any later version.
+
+Omega is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+Omega. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+// Definitions of all global game-state variables declared extern in glob.h.
+// Moved here from omega.cpp so front-ends other than main() can link them.
+
+#include "glob.h"
+
+#include <array>
+#include <string>
+
+const char *Omegalib;
+
+int CitySiteList[NUMCITYSITES][3];
+
+int  LENGTH               = MAXLENGTH;
+int  WIDTH                = MAXWIDTH;
+bool terminal_size_too_small;
+bool received_directions  = false;
+bool IsMenu               = false;
+long GameStatus           = 0L;
+int  ScreenLength         = 0;
+int  ScreenWidth          = 0;
+
+player                               Player;
+terrain                              Country[MAXWIDTH][MAXLENGTH];
+std::unique_ptr<level>               TempLevel;
+std::unique_ptr<level>               City;
+std::vector<std::unique_ptr<level>>  Dungeon;
+level                               *Level              = nullptr;
+
+int Villagenum          = 0;
+int ScreenOffset        = 0;
+int HorizontalOffset    = 0;
+int MaxDungeonLevels    = 0;
+int Current_Dungeon     = -1;
+int Current_Environment = E_CITY;
+int Last_Environment    = E_COUNTRYSIDE;
+int Dirs[2][9];
+int Cmd                 = 's';
+int Command_Duration    = 0;
+
+monster *Arena_Monster  = nullptr;
+int      Arena_Opponent = 0;
+int      Arena_Victory  = 0;
+
+int Imprisonment  = 0;
+int Precipitation = 0;
+int Lunarity      = 0;
+int Phase         = 0;
+int Date          = 0;
+int Pawndate      = -1;
+
+std::array<std::unique_ptr<object>, PAWNITEMS> Pawnitems;
+
+int SymbolUseDay  = -1;
+int SymbolUseHour = -1;
+int ViewDay       = -1;
+int ViewHour      = -1;
+int ZapDay        = -1;
+int ZapHour       = -1;
+int HelmDay       = -1;
+int HelmHour      = -1;
+
+int Constriction = 0;
+int Blessing     = false;
+int LastDay      = -1;
+int RitualDay    = -1;
+int RitualHour   = -1;
+int RitualRoom   = -1;
+
+int Lawstone  = 0;
+int Chaostone = 0;
+int Mindstone = 0;
+int Searchnum = 1;
+int Behavior;
+int Verbosity = VERBOSE;
+
+long Time      = 0;
+int  Tick      = 0;
+long Gymcredit = 0;
+int  Spellsleft  = 0;
+int  Studiesleft = 0;
+
+int StarGemUse = 0;
+int HiMagicUse = 0;
+int HiMagic    = 0;
+
+long Balance     = 0;
+long FixedPoints = 0;
+
+int LastTownLocX    = 0;
+int LastTownLocY    = 0;
+int LastCountryLocX = 0;
+int LastCountryLocY = 0;
+
+std::string Password;
+int         MazeNum = 0;
+
+std::forward_list<std::unique_ptr<object>> Condoitems;
+
+int Shadowlordbehavior, Archmagebehavior, Primebehavior, Commandantbehavior;
+int Championbehavior, Priestbehavior[7], Hibehavior, Dukebehavior;
+int Chaoslordbehavior, Lawlordbehavior, Justiciarbehavior, Grandmasterbehavior;
+
+std::string Shadowlord, Archmage, Prime, Commandant, Duke;
+std::string Champion, Priest[7], Hiscorer, Hidescrip;
+std::string Chaoslord, Lawlord, Justiciar, Grandmaster;
+
+int Shadowlordlevel, Archmagelevel, Primelevel, Commandantlevel, Dukelevel;
+int Championlevel, Priestlevel[7], Hilevel, Justiciarlevel, Grandmasterlevel;
+long Hiscore       = 0L;
+int  Chaoslordlevel = 0, Lawlordlevel = 0, Chaos = 0, Law = 0;
+
+int twiddle        = false;
+int saved          = false;
+int onewithchaos   = false;
+int club_hinthour  = 0;
+int winnings       = 0;
+int tavern_hinthour;
+int scroll_ids[30];
+int potion_ids[30];
+int stick_ids[30];
+int ring_ids[30];
+int cloak_ids[30];
+int boot_ids[30];
+
+int deepest[E_MAX + 1];
+int level_seed[E_MAX + 1];

--- a/src/interactive_menu.hpp
+++ b/src/interactive_menu.hpp
@@ -18,6 +18,10 @@ Omega. If not, see <https://www.gnu.org/licenses/>.
 #ifndef OMEGA_INTERACTIVE_MENU_HPP_
 #define OMEGA_INTERACTIVE_MENU_HPP_
 
+#ifdef OMEGA_CURSES_STUB
+#  include "interactive_menu_stub.hpp"
+#else
+
 #include <curses.h>
 #include <string>
 #include <vector>
@@ -42,5 +46,7 @@ private:
   uint16_t width;
   uint16_t height;
 };
+
+#endif
 
 #endif

--- a/src/level.h
+++ b/src/level.h
@@ -4,8 +4,9 @@
 #include "defs.h"
 #include "monster.h"
 
+#include "omega_curses.h"
+
 #include <ctime>
-#include <curses.h>
 #include <forward_list>
 #include <vector>
 

--- a/src/monster.h
+++ b/src/monster.h
@@ -21,7 +21,8 @@ Omega. If not, see <https://www.gnu.org/licenses/>.
 
 #include "object.h"
 
-#include <curses.h>
+#include "omega_curses.h"
+
 #include <forward_list>
 #include <memory>
 #include <string>

--- a/src/object.h
+++ b/src/object.h
@@ -19,7 +19,8 @@ Omega. If not, see <https://www.gnu.org/licenses/>.
 #ifndef OMEGA_OBJECT_H_
 #define OMEGA_OBJECT_H_
 
-#include <curses.h>
+#include "omega_curses.h"
+
 #include <string>
 
 struct object

--- a/src/omega.cpp
+++ b/src/omega.cpp
@@ -16,185 +16,23 @@ You should have received a copy of the GNU General Public License along with
 Omega. If not, see <https://www.gnu.org/licenses/>.
 */
 
-// this file includes main() and some top-level functions
-// omega.cpp
+// Standalone entry point: signal handlers and main().
+// Global variable definitions live in globals.cpp.
+// Game initialisation and loop live in game_session.cpp.
 
+#include "game_session.h"
 #include "glob.h"
 #include "scr.h"
 
-#include <array>
 #include <csignal>
 #include <cstdlib>
-#include <ctime>
-#include <filesystem>
-#include <format>
-#include <limits>
-#include <random>
-#include <string>
-#include <vector>
+
 #ifdef PDC_GL_BUILD
 extern "C"
 {
 #  include <pdcgl.h>
 }
 #endif
-// Note: in order to avoid a memory bug I've been told about, I'm
-// explicitly initializing every global to something.
-
-extern std::string get_username();
-extern bool title_menu();
-extern void init_game(bool play_yourself = false);
-
-// most globals originate in omega.cpp
-
-const char *Omegalib; // contains the path to the library files
-
-// locations of city sites [0] - found, [1] - x, [2] - y
-int CitySiteList[NUMCITYSITES][3];
-
-// Currently defined in caps since it is now a variable, was a constant
-int LENGTH = MAXLENGTH;
-int WIDTH  = MAXWIDTH;
-bool terminal_size_too_small;
-
-bool received_directions = false;
-bool IsMenu              = false;
-long GameStatus          = 0L; // Game Status bit vector
-int ScreenLength         = 0;  // How large is level window
-int ScreenWidth          = 0;
-player Player;                               // the player
-terrain Country[MAXWIDTH][MAXLENGTH];        // The countryside
-std::unique_ptr<level> TempLevel;            // Temporary level
-std::unique_ptr<level> City;                 // The city of Rampart
-std::vector<std::unique_ptr<level>> Dungeon; // Current Dungeon
-level *Level            = nullptr;           // Pointer to current Level
-int Villagenum          = 0;                 // Current Village number
-int ScreenOffset        = 0;                 // Vertical offset of level
-int HorizontalOffset    = 0;                 // Horizontal offset of level
-int MaxDungeonLevels    = 0;             // Deepest level allowed in dungeon
-int Current_Dungeon     = -1;            // What is Dungeon now
-int Current_Environment = E_CITY;        // Which environment are we in
-int Last_Environment    = E_COUNTRYSIDE; // Which environment were we in
-int Dirs[2][9];                          // 9 xy directions
-int Cmd                  = 's';          // last player command
-int Command_Duration     = 0;            // how long does current command take
-monster *Arena_Monster   = nullptr;      // Opponent in arena
-int Arena_Opponent       = 0;            // case label of opponent in l_arena()
-int Arena_Victory        = 0;            // did player win in arena?
-int Imprisonment         = 0;            // amount of time spent in jail
-int Precipitation        = 0;            // Hours of rain, snow, etc
-int Lunarity             = 0;            // Effect of the moon on character
-int Phase                = 0;            // Phase of the moon
-int Date                 = 0;            // Starting date
-int Pawndate             = -1;           // Pawn Shop item generation date
-std::array<std::unique_ptr<object>, PAWNITEMS> Pawnitems; // items in pawn shop
-int SymbolUseDay  = -1;
-int SymbolUseHour = -1; // holy symbol use marker
-int ViewDay       = -1;
-int ViewHour      = -1; // crystal ball use marker
-int ZapDay        = -1;
-int ZapHour       = -1; // staff of enchantment use marker
-int HelmDay       = -1;
-int HelmHour      = -1;    // helm of teleportation use marker
-int Constriction  = 0;     // Dragonlord Attack State
-int Blessing      = false; // Altar Blessing State
-int LastDay       = -1;    // DPW date of dole
-int RitualDay     = -1;
-int RitualHour    = -1;                                   // last use of ritual magic
-int RitualRoom    = -1;                                   // last room of ritual magic
-int Lawstone      = 0;                                    // magic stone counter
-int Chaostone     = 0;                                    // magic stone counter
-int Mindstone     = 0;                                    // magic stone counter
-int Searchnum     = 1;                                    // number of times to search on 's'
-int Behavior;                                             // Player NPC behavior
-int Verbosity = VERBOSE;                                  // verbosity level
-long Time     = 0;                                        // turn number
-int Tick      = 0;                                        // 10 a turn; action coordinator
-long Gymcredit      = 0;                                  // credit at rampart gym
-int Spellsleft      = 0;                                  // research allowance at college
-int Studiesleft     = 0;                                  // Study allowance at monastery
-int StarGemUse      = 0;                                  // last date of star gem use
-int HiMagicUse      = 0;                                  // last date of high magic use
-int HiMagic         = 0;                                  // current level for l_throne
-long Balance        = 0;                                  // bank account
-long FixedPoints    = 0;                                  // points are frozen after adepthood
-int LastTownLocX    = 0;                                  // previous position in village or city
-int LastTownLocY    = 0;                                  // previous position in village or city
-int LastCountryLocX = 0;                                  // previous position in countryside
-int LastCountryLocY = 0;                                  // previous position in countryside
-std::string Password;                                     // autoteller password
-int MazeNum = 0;
-
-std::forward_list<std::unique_ptr<object>> Condoitems;                   // Items in condo
-
-// high score names, levels, behavior
-int Shadowlordbehavior, Archmagebehavior, Primebehavior, Commandantbehavior;
-int Championbehavior, Priestbehavior[7], Hibehavior, Dukebehavior;
-int Chaoslordbehavior, Lawlordbehavior, Justiciarbehavior, Grandmasterbehavior;
-std::string Shadowlord, Archmage, Prime, Commandant, Duke;
-std::string Champion, Priest[7], Hiscorer, Hidescrip;
-std::string Chaoslord, Lawlord, Justiciar, Grandmaster;
-int Shadowlordlevel, Archmagelevel, Primelevel, Commandantlevel, Dukelevel;
-int Championlevel, Priestlevel[7], Hilevel, Justiciarlevel, Grandmasterlevel;
-long Hiscore       = 0L;
-int Chaoslordlevel = 0, Lawlordlevel = 0, Chaos = 0, Law = 0;
-
-// New globals which used to be statics
-int twiddle       = false;
-int saved         = false;
-int onewithchaos  = false;
-int club_hinthour = 0;
-int winnings      = 0;
-int tavern_hinthour;
-int scroll_ids[30];
-int potion_ids[30];
-int stick_ids[30];
-int ring_ids[30];
-int cloak_ids[30];
-int boot_ids[30];
-
-int deepest[E_MAX + 1];
-int level_seed[E_MAX + 1]; // random number seed that generated level
-
-// environment is the environment about to be generated, or -1 for the first
-// time, or -2 if we want to restore the random number point
-void initrand(int environment, int level)
-{
-  static int store;
-  int seed;
-
-  if(environment >= 0)
-  {
-    store = random_range((std::numeric_limits<int>::max)());
-  }
-  // Pseudo Random Seed
-  if(environment == E_RANDOM)
-  {
-    seed = static_cast<int>(time(nullptr));
-  }
-  else if(environment == E_RESTORE)
-  {
-    seed = store;
-  }
-  else
-  {
-    seed = level_seed[environment] + 1000 * level;
-  }
-  generator.seed(seed);
-}
-
-bool game_restore(const std::filesystem::path &save_file_path)
-{
-  if(std::filesystem::exists(save_file_path) && restore_game(save_file_path.string()))
-  {
-    std::filesystem::remove(save_file_path);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
-}
 
 void signalexit(int)
 {
@@ -205,7 +43,7 @@ void signalexit(int)
   reply = ynq();
   if(reply == 'y')
   {
-    save(true); // force save
+    save(true);
   }
   else if(reply == EOF)
   {
@@ -216,8 +54,6 @@ void signalexit(int)
   exit(0);
 }
 
-void omega_title();
-
 int main(int, char *[])
 {
 #ifdef PDC_GL_BUILD
@@ -226,7 +62,6 @@ int main(int, char *[])
   pdc_resize_mode = PDC_GL_RESIZE_SCALE;
 #endif
 
-  // always catch ^c and hang-up signals
 #ifdef SIGINT
   signal(SIGINT, quit);
 #endif
@@ -261,157 +96,12 @@ int main(int, char *[])
 #  endif
 #endif
 
-#ifdef USER_DEFINED_OMEGALIB
-  if(!(Omegalib = getenv("OMEGALIB")))
-#endif
+  const InitResult result = init_game_session();
+  if(result == InitResult::Failed)
   {
-    Omegalib = OMEGALIB;
+    return 1;
   }
 
-  // if filecheck is false, some necessary data files are missing
-  if(!filecheck())
-  {
-    exit(1);
-  }
-
-  // all kinds of initialization
-  initgraf();
-#ifdef PDC_GL_BUILD
-  PDC_set_title("Omega Rebirth");
-#endif
-  initdirs();
-  initrand(E_RANDOM, 0);
-
-  omega_title();
-
-  Player.name         = get_username();
-  Player.name.front() = std::toupper(Player.name.front());
-  optionset(SHOW_COLOUR, Player);
-  bool continuing = false;
-
-#ifdef MULTI_USER_SYSTEM
-  continuing = game_restore(std::format("{}saves/{}/{}.sav", Omegalib, get_username(), Player.name));
-
-  showscores();
-  if(!continuing)
-  {
-    init_game(false);
-  }
-#else
-  continuing = title_menu();
-#endif
-
-  if(continuing)
-  {
-    queue_message("Your adventure continues....");
-    if(Lunarity == 1)
-    {
-      queue_message("You feel vitalized by the moon!");
-    }
-    else if(Lunarity == -1)
-    {
-      queue_message("The feel enervated by the moon!");
-    }
-  }
-
-  timeprint();
-  calc_melee();
-  if(Current_Environment != E_COUNTRYSIDE)
-  {
-    showroom(Level->site[Player.x][Player.y].roomnumber);
-  }
-  else
-  {
-    terrain_check(false);
-  }
-
-  if(optionp(SHOW_COLOUR, Player))
-  {
-    colour_on();
-  }
-  else
-  {
-    colour_off();
-  }
-
-  screencheck(Player.x, Player.y);
-  xredraw();
-
-  // game cycle
-  if(!continuing)
-  {
-    time_clock(true);
-  }
-  while(true)
-  {
-    if(Current_Environment == E_COUNTRYSIDE)
-    {
-      p_country_process();
-    }
-    else
-    {
-      time_clock(false);
-    }
-  }
-}
-
-// Start up game with new dungeons; start with player in city
-void init_world()
-{
-  for(int env = 0; env <= E_MAX; ++env)
-  {
-    level_seed[env] = random_range((std::numeric_limits<int>::max)());
-  }
-  load_country();
-  for(int i = 0; i < NUMCITYSITES; ++i)
-  {
-    CitySiteList[i][0] = false;
-  }
-  load_city(true);
-  WIDTH               = 64;
-  LENGTH              = 64;
-  Player.x            = 62;
-  Player.y            = 21;
-  Current_Environment = E_CITY;
-  queue_message("You pass through the massive gates of Rampart, the city.");
-}
-
-// set variable item names
-void inititem(int reset)
-{
-  if(reset)
-  {
-    shuffle(scroll_ids, 30);
-    shuffle(potion_ids, 20);
-    shuffle(stick_ids, 20);
-    shuffle(boot_ids, 20);
-    shuffle(cloak_ids, 20);
-    shuffle(ring_ids, 20);
-  }
-  for(int i = 0; i < NUMSCROLLS; ++i)
-  {
-    Objects[SCROLLID + i].objstr = scrollname(i);
-  }
-  for(int i = 0; i < NUMPOTIONS; ++i)
-  {
-    Objects[POTIONID + i].objstr = potionname(i);
-  }
-  Objects[ARTIFACTID + 10].objstr = potionname(18);
-  Objects[ARTIFACTID + 13].objstr = potionname(19);
-  for(int i = 0; i < NUMSTICKS; ++i)
-  {
-    Objects[STICKID + i].objstr = stickname(i);
-  }
-  for(int i = 0; i < NUMBOOTS; ++i)
-  {
-    Objects[BOOTID + i].objstr = bootname(i);
-  }
-  for(int i = 0; i < NUMCLOAKS; ++i)
-  {
-    Objects[CLOAKID + i].objstr = cloakname(i);
-  }
-  for(int i = 0; i < NUMRINGS; ++i)
-  {
-    Objects[RINGID + i].objstr = ringname(i);
-  }
+  run_game_loop(result == InitResult::NewGame);
+  return 0;
 }

--- a/src/omega_curses.h
+++ b/src/omega_curses.h
@@ -15,7 +15,8 @@ You should have received a copy of the GNU General Public License along with
 Omega. If not, see <https://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#ifndef OMEGA_CURSES_H_
+#define OMEGA_CURSES_H_
 
 // Single point of indirection for the curses API. Alternative front-ends
 // (e.g. a graphical port) define OMEGA_CURSES_STUB and supply curses_stub.h,
@@ -27,3 +28,5 @@ Omega. If not, see <https://www.gnu.org/licenses/>.
 #else
 #  include <curses.h>
 #endif
+
+#endif // OMEGA_CURSES_H_

--- a/src/omega_curses.h
+++ b/src/omega_curses.h
@@ -1,0 +1,29 @@
+/*
+Copyright (C) by Ken Paulson, 2026
+
+This file is part of Omega.
+
+Omega is free software: you can redistribute it and/or modify it under the terms
+of the GNU General Public License as published by the Free Software Foundation,
+either version 3 of the License, or (at your option) any later version.
+
+Omega is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+Omega. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+// Single point of indirection for the curses API. Alternative front-ends
+// (e.g. a graphical port) define OMEGA_CURSES_STUB and supply curses_stub.h,
+// which provides the curses types, constants, and function signatures while
+// routing output to the replacement renderer. The standard build includes
+// the real curses header.
+#ifdef OMEGA_CURSES_STUB
+#  include "curses_stub.h"
+#else
+#  include <curses.h>
+#endif


### PR DESCRIPTION
As you know I've been working on a Godot 4 renderer for Omega. This PR is the
small enabling layer that lets that work (and any other alternative front-end —
SDL, web, tests) live entirely out of tree, without patching game code. All the
Godot-specific code stays in my fork; nothing here references it.

Two commits, each builds and runs on its own:

**1. Extract globals and game session from omega.cpp**
- Global variable definitions move to `globals.cpp`; game init and the main
  loop move to `game_session.cpp`. `omega.cpp` is now just signal handlers
  and a thin `main()`.
- CMake gains an `omega-core` static library with the game logic; the `omega`
  executable links it plus the curses front-end files. Build commands and
  output are unchanged.
- `init_game_session()` now returns once the world is set up and drawn
  (before the first turn), and `run_game_loop(bool reset_clock)` runs the
  first turn. The call sequence is identical — this just gives an embedding
  front-end a clean "game is ready" point between init and the loop.

**2. Route curses includes through omega_curses.h**
- `defs.h`, `object.h`, `monster.h`, `level.h`, and `clrgen.cpp` include a new
  one-page `omega_curses.h` instead of `<curses.h>` directly. Normally it just
  includes `<curses.h>`; if `OMEGA_CURSES_STUB` is defined, it includes a
  `curses_stub.h` supplied by the front-end's build. `interactive_menu.hpp`
  gets the same treatment.
- Nothing in this repo defines `OMEGA_CURSES_STUB`, so the standard build is
  byte-for-byte the same code as before.

No functional changes. Verified on Windows (MSVC 2022): clean build at each
commit, new game starts, plays, and saves/restores as before. The Lunarity
restore message recently added on `development` is carried over verbatim into
`game_session.cpp`.
