### PR TITLE
Fix typo in Lunarity restore message

### DIFF
--- a/src/omega.cpp
+++ b/src/omega.cpp
@@ -310,7 +310,7 @@ int main(int, char *[])
     }
     else if(Lunarity == -1)
     {
-      queue_message("The feel enervated by the moon!");
+      queue_message("You feel enervated by the moon!");
     }
   }
 


### PR DESCRIPTION
One-word fix in the Lunarity message shown when restoring a save: 'The feel enervated by the moon!' should be 'You feel enervated by the moon!', matching the vitalized message beside it. Heads-up: #44 carries this line verbatim into game_session.cpp, so whichever PR lands second will need the same one-word touch-up there — happy to update mine if this goes in first.